### PR TITLE
Properly keep track of all three services running in the container

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ we also need to configure SASL_SSL to be able to access the internal cluster usi
 - `CONNECT_[(CONSUMER/PRODUCER)]_SSL_TRUSTSTORE_PASSWORD`
 - `CONNECT_[(CONSUMER/PRODUCER)]_SASL_JAAS_CONFIG`
 
-Configuration of all environment variables not defined in [nais/nais-dev.yaml](nais/nais-dev.yaml) and [nais/nais-prod.yaml](nais/nais-prod.yaml) is handled through Vault or NAV specific environment variables in [run.sh](run.sh).
+Configuration of all environment variables not defined in [nais/nais-dev.yaml](nais/nais-dev.yaml) and [nais/nais-prod.yaml](nais/nais-prod.yaml) is handled through Vault or NAV specific environment variables in [s6/connect/run](s6/connect/run).
 
 Vault -> ENV var mapping:
 

--- a/run-jmx-prometheus.sh
+++ b/run-jmx-prometheus.sh
@@ -1,1 +1,0 @@
-java -XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap -XX:MaxRAMFraction=1 -XshowSettings:vm -jar /usr/local/jmx_prometheus/jmx_prometheus_httpserver.jar 5556 /usr/local/jmx_prometheus/jmx-kafka-connect-prometheus.yml

--- a/s6/connect/finish
+++ b/s6/connect/finish
@@ -1,0 +1,6 @@
+#!/usr/bin/execlineb -S0
+
+foreground {
+  echo "connect finished, stopping everything"
+}
+s6-svscanctl -t /var/run/s6/services

--- a/s6/connect/run
+++ b/s6/connect/run
@@ -26,4 +26,4 @@ export CONNECT_CONFIG_PROVIDERS=vault
 export CONNECT_CONFIG_PROVIDERS_VAULT_CLASS=no.nav.kafkaconnect.VaultConfigProvider
 export CUB_CLASSPATH=${CUB_CLASSPATH}:/usr/share/java/vault-provider/*
 
-exec bash -c "{ /etc/confluent/docker/run & nginx -g 'daemon off;' & /usr/local/bin/run-jmx-prometheus.sh; }"
+exec bash -c /etc/confluent/docker/run

--- a/s6/jmx_exporter/finish
+++ b/s6/jmx_exporter/finish
@@ -1,0 +1,6 @@
+#!/usr/bin/execlineb -S0
+
+foreground {
+  echo "jmx_exporter exited, will restart unless this crashes 6 times in 60 seconds"
+}
+s6-permafailon 60 6 0-255 true

--- a/s6/jmx_exporter/run
+++ b/s6/jmx_exporter/run
@@ -1,0 +1,9 @@
+#!/usr/bin/execlineb -P
+java
+-XX:+UnlockExperimentalVMOptions
+-XX:+UseCGroupMemoryLimitForHeap
+-XX:MaxRAMFraction=1
+-XshowSettings:vm
+-jar /usr/local/jmx_prometheus/jmx_prometheus_httpserver.jar
+5556
+/usr/local/jmx_prometheus/jmx-kafka-connect-prometheus.yml

--- a/s6/nginx/finish
+++ b/s6/nginx/finish
@@ -1,0 +1,6 @@
+#!/usr/bin/execlineb -S0
+
+foreground {
+  echo "nginx finished, stopping everything"
+}
+s6-svscanctl -t /var/run/s6/services

--- a/s6/nginx/run
+++ b/s6/nginx/run
@@ -1,0 +1,2 @@
+#!/usr/bin/execlineb -P
+nginx -g "daemon off;"

--- a/testing/docker-compose.yaml
+++ b/testing/docker-compose.yaml
@@ -47,7 +47,7 @@ services:
     ports:
       - "8083:8083"
       - "8084:8084"
-      - "5555:5555"
+      - "5556:5556"
     environment:
       CONNECT_REST_PORT: 8084
       CONNECT_GROUP_ID: compose-connect-group
@@ -82,22 +82,6 @@ services:
       POSTGRES_PASSWORD: test
     ports:
       - "5432:5432"
-  prometheus-jmx-exporter:
-    image: solsson/kafka-prometheus-jmx-exporter@sha256:6f82e2b0464f50da8104acd7363fb9b995001ddff77d248379f8788e78946143
-    volumes:
-      - ./jmx-kafka-connect-prometheus.yml:/etc/jmx-kafka-connect/jmx-kafka-connect-prometheus.yml
-    entrypoint:
-      - java
-      - -XX:+UnlockExperimentalVMOptions
-      - -XX:+UseCGroupMemoryLimitForHeap
-      - -XX:MaxRAMFraction=1
-      - -XshowSettings:vm
-      - -jar
-      - jmx_prometheus_httpserver.jar
-      - "5556"
-      - /etc/jmx-kafka-connect/jmx-kafka-connect-prometheus.yml
-    ports:
-      - "5556:5556"
   vault:
     image: vault:1.3.3
     ports:


### PR DESCRIPTION
Use s6-overlay to crash the container if kafka connect or nginx stops,
or if the JMX exporter fails 6 times in 60 seconds.

s6 is a tiny supervisor, very suited to being used in docker containers. The downside is that s6 is somewhat weird, and not commonly used.

I've only used s6 once before, and I'm not 100% sold on using it, so a discussion about options are welcome.

s6-overlay: https://github.com/just-containers/s6-overlay
s6: http://skarnet.org/software/s6/overview.html
